### PR TITLE
fixed bug in LogInPages.js when making POST call to backend via /login

### DIFF
--- a/FE/src/components/React-Router/LogInPages.js
+++ b/FE/src/components/React-Router/LogInPages.js
@@ -57,7 +57,7 @@ const handleSubmit = async (e) => {
     const response = await fetch("/login", {
         method: "POST",
         headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({userID:username, password:password})
+        body: JSON.stringify({username, password})
     });
 
     // Parse the response as JSON


### PR DESCRIPTION
LogInPages.js had error on line 60 when passing arguments to backend via /logn
`body: JSON.stringify({username, password})`